### PR TITLE
Description scraping from wiki

### DIFF
--- a/descriptions/wikipedia_scrape.py
+++ b/descriptions/wikipedia_scrape.py
@@ -1,0 +1,53 @@
+import re
+import requests as req
+from tqdm import tqdm
+import pandas as pd
+import json
+from constants import KAGGLE_HERBARIUM_22_TRAIN_CSV
+
+df = pd.read_csv(KAGGLE_HERBARIUM_22_TRAIN_CSV)
+print(df.columns)
+
+output_file = "wiki_descriptions.json"
+
+labels = (df["genus"] + " " + df["species"]).unique().tolist()
+print(f"Number of unique species (labels): {len(labels)}")
+print(f"Labels: {labels[:5]}")
+
+species_found = []
+n_found = 0
+for sp in tqdm(labels):
+    page = sp.replace(" ", "_")
+    URL = f"https://en.wikipedia.org/w/index.php?title={page}&action=raw"
+    response = req.get(URL)
+    if "Wikimedia Error" not in response.text:
+        remove_curly = re.sub(r"{{.*?}}", "", response.text, flags=re.DOTALL)
+        remove_html = re.sub(r"<.*?>", "", remove_curly, flags=re.DOTALL)
+        remove_brackets = re.sub(
+            r"\[\[Category.*?\]\]", "", remove_html, flags=re.DOTALL)
+        desc = remove_brackets.strip()
+
+        tag = "== Description =="
+        start = desc.find(tag)
+        end = desc.find("==", start + len(tag))
+
+        if start != -1 and end != -1:
+            relevant_text = desc[start:end].strip()
+            species_found.append({"species": sp, "description": relevant_text})
+        else:
+            species_found.append({"species": sp, "description": desc})
+
+        n_found += 1
+
+    if n_found % 100 == 0 and n_found > 0:
+        print(f"Number of species descriptions found: {n_found}")
+
+print(f"Number of species descriptions found: {len(species_found)}")
+
+
+json.dump(species_found, open("species_found.json", "w"))
+
+first = species_found[0]
+print(f"Species: {first['species']}")
+print(f"Description: {first['description'][:200]}")
+print(f"Length: {len(first['description'])}")


### PR DESCRIPTION
Was able to find Wikipedia articles with descriptions for 5760 out of 15501 species in the Kaggle22 dataset. Didn't push the dataset because it's too big. Running `wikipedia_scrape.py` will create a `species_found.json` file of the following schema: 

```{json}
[

{
"species": species_name, 
"description:" Either the full wikipedia article or only the "Description" section,
},

...
]
```
