### PR TITLE
Fix two smoke-test blockers: W&B-disabled callback crash + None multi-task metrics

### DIFF
--- a/finetuning/SWIN/SWIN_finetuning_advanced.py
+++ b/finetuning/SWIN/SWIN_finetuning_advanced.py
@@ -1779,8 +1779,11 @@ def main():
         )
 
     # Swap in filtered W&B callback to suppress label2id/id2label from config uploads.
-    trainer.remove_callback(WandbCallback)
-    trainer.add_callback(FilteredWandbCallback)
+    # Only when W&B is enabled: instantiating a WandbCallback while WANDB_DISABLED is set
+    # (the wandb.enabled=false path, e.g. smoke tests) raises a RuntimeError.
+    if config['wandb'].get('enabled', True):
+        trainer.remove_callback(WandbCallback)
+        trainer.add_callback(FilteredWandbCallback)
 
     # Weight EMA (Tier 2.6): copies averaged weights into the model at train end,
     # so the final evaluate()/save_model() below reflect the EMA weights.

--- a/finetuning/SWIN/SWIN_finetuning_advanced.py
+++ b/finetuning/SWIN/SWIN_finetuning_advanced.py
@@ -1392,7 +1392,10 @@ def main():
                 metrics["genus_predictions_available"] = True
                 metrics["family_predictions_available"] = True
 
-            return metrics
+            # Drop metrics that weren't computed (None). The custom eval loop only
+            # reconstructs species predictions, so family/genus metrics are None here —
+            # and HF's log_metrics/save_metrics numeric-format every value and crash on None.
+            return {k: v for k, v in metrics.items() if v is not None}
     else:
         def preprocess_logits_for_metrics(logits, labels):
             """


### PR DESCRIPTION
## Problem

`main` (after PR #37) crashes any run with **W&B disabled** — including every smoke test
(`--set wandb.enabled=false`). The trainer unconditionally swaps in the filtered W&B callback:

```python
trainer.remove_callback(WandbCallback)
trainer.add_callback(FilteredWandbCallback)
```

When W&B is disabled, the code sets `WANDB_DISABLED=true` and `report_to=none`, so there's no
`WandbCallback` to replace — and instantiating a `WandbCallback` subclass while `WANDB_DISABLED`
is set raises:

```
RuntimeError: You specified `report_to='wandb'` but also set the `WANDB_DISABLED`
environment variable.
```

This fires at `trainer.add_callback(FilteredWandbCallback)`, before training starts.

## Fix

Only perform the callback swap when W&B is actually enabled:

```python
if config['wandb'].get('enabled', True):
    trainer.remove_callback(WandbCallback)
    trainer.add_callback(FilteredWandbCallback)
```

When W&B is enabled the behavior is unchanged (the filtered callback still suppresses
`label2id`/`id2label` from the config upload). When disabled, the swap is skipped and the run
proceeds.

## Context

This guard was developed alongside the SWIN-L 384 work on `finetuning-trg` but its push got
tangled in a concurrent rebase and wasn't included in the merge to `main`, so the bug is
currently live. Verified with `py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)