### PR TITLE
Fix: lr_scheduler_type must be a SchedulerType enum (model-card crash)

### DIFF
--- a/finetuning/SWIN/SWIN_finetuning_advanced.py
+++ b/finetuning/SWIN/SWIN_finetuning_advanced.py
@@ -1150,7 +1150,9 @@ def main():
         if 'eta_min' in sched_kwargs:
             eta_min = sched_kwargs.pop('eta_min')
             if str(config['training'].get('lr_scheduler_type', '')).lower() == 'cosine':
-                training_args.lr_scheduler_type = 'cosine_with_min_lr'
+                # assign the SchedulerType enum (not a raw str) so downstream code that
+                # reads `.value` (e.g. create_model_card) doesn't break
+                training_args.lr_scheduler_type = transformers.SchedulerType('cosine_with_min_lr')
                 sched_kwargs['min_lr'] = eta_min
                 print(f"__CUSTOM__: Mapped cosine eta_min={eta_min} -> "
                       f"lr_scheduler_type=cosine_with_min_lr, min_lr={eta_min}")


### PR DESCRIPTION
## Problem

The cosine `eta_min` → `cosine_with_min_lr` compatibility shim (added for transformers
4.57.x) assigned a **raw string** to `training_args.lr_scheduler_type`:

```python
training_args.lr_scheduler_type = 'cosine_with_min_lr'
```

`get_scheduler` coerces strings, so training/eval/save all worked — but the final
`trainer.create_model_card()` does:

```python
hyperparameters["lr_scheduler_type"] = trainer.args.lr_scheduler_type.value
```

and crashes with `AttributeError: 'str' object has no attribute 'value'` **after** the run
has otherwise completed (model already saved).

## Fix

Assign the proper enum so `.value` works:

```python
training_args.lr_scheduler_type = transformers.SchedulerType('cosine_with_min_lr')
```

`get_scheduler` still accepts it (enum is its native type), and `create_model_card` now
succeeds.

## Context

Surfaced by the SWIN-L 384 concrete-run smoke test, which now runs fully end to end
(train → EMA → eval → save) and exits cleanly with this fix. Last of the smoke-test
blockers (after PR #38's W&B-callback and None-metrics fixes). Verified `py_compile` and
that `SchedulerType('cosine_with_min_lr').value == 'cosine_with_min_lr'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)