### PR TITLE
submit_concrete.sh: default output to the submitter's own workspace

### DIFF
--- a/finetuning/SWIN/submit_concrete.sh
+++ b/finetuning/SWIN/submit_concrete.sh
@@ -25,10 +25,16 @@
 #
 # Nothing is auto-submitted by Claude — run this yourself when ready.
 
+# Default OUT_BASE to *this checkout's* output dir, derived from the script location
+# (.../<workspace>/herbdl/finetuning/SWIN/submit_concrete.sh -> .../herbdl/finetuning/output/SWIN),
+# so runs land in the submitter's own workspace regardless of who authored the config.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
 SEEDS=${SEEDS:-"0 1 2"}
 CONFIG=${CONFIG:-"configs_advanced/swin_large_384_concrete.yml"}
 RUN_PREFIX=${RUN_PREFIX:-"SWIN_L_384_CONCRETE"}
-OUT_BASE=${OUT_BASE:-"/projectnb/herbdl/workspaces/faridkar/herbdl/finetuning/output/SWIN"}
+OUT_BASE=${OUT_BASE:-"${REPO_ROOT}/finetuning/output/SWIN"}
 NGPUS=${NGPUS:-1}
 GPU_MEM=${GPU_MEM:-"80G"}
 EMAIL=${EMAIL:-"faridkar@bu.edu"}


### PR DESCRIPTION
## Problem

`submit_concrete.sh` hardcoded `OUT_BASE` to faridkar's workspace:

```bash
OUT_BASE=${OUT_BASE:-"/projectnb/herbdl/workspaces/faridkar/herbdl/finetuning/output/SWIN"}
```

So another user running `bash submit_concrete.sh` sees jobs targeting faridkar's directory:

```
Submitted seed 0: job 5989358  ->  /projectnb/herbdl/workspaces/faridkar/.../SWIN_L_384_CONCRETE_SEED0
```

(The trainer's runtime path auto-relocation rewrites it back to the runner's workspace, so
output didn't actually land in the wrong place — but the printed path is misleading and the
behavior shouldn't depend on that safety net.)

## Fix

Derive `OUT_BASE` from the script's own location, so it points at the submitter's checkout:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
OUT_BASE=${OUT_BASE:-"${REPO_ROOT}/finetuning/output/SWIN"}
```

Now a `tgardos` checkout defaults to `.../workspaces/tgardos/herbdl/finetuning/output/SWIN`,
a `faridkar` checkout to his, etc. Still overridable via `OUT_BASE=...`. Verified the derived
path and `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)