### PR TITLE
Docs: runtime/48h math + 4-GPU (DDP) launch variant + resume

### DIFF
--- a/finetuning/SWIN/CONCRETE_RUN_README.md
+++ b/finetuning/SWIN/CONCRETE_RUN_README.md
@@ -176,18 +176,20 @@ command after each 48h job ends — ~4 sequential jobs reach 100 epochs.
 | 4    | 2                             | ~44h → ≈ one 48h job |
 
 ⚠️ **DDP multiplies the effective batch by `NGPUS`** (each GPU runs its own
-`per_device_batch × grad_accum`). The config targets effective batch **128**, so **reduce
-`gradient_accumulation_steps`** to keep it there (and keep the LR valid). `submit_concrete.sh`
-doesn't forward extra `--set` args, so either set `gradient_accumulation_steps: 2` in
-`configs_advanced/swin_large_384_concrete.yml` for the multi-GPU run, or submit directly
-(below) for full control.
+`per_device_batch × grad_accum`). The base config targets effective batch **128**, so the
+4-GPU run needs `gradient_accumulation_steps: 2` (= `16 × 2 × 4`). A dedicated config —
+[`configs_advanced/swin_large_384_concrete_4gpu.yml`](configs_advanced/swin_large_384_concrete_4gpu.yml)
+— is identical to the base run but with `grad_accum: 2`, so the launcher path just works:
 
-**4-GPU run via the launcher** (set `gradient_accumulation_steps: 2` in the config first):
+**4-GPU run via the launcher** (no edits needed):
 ```bash
 cd finetuning/SWIN
-EMAIL=tgardos@bu.edu NGPUS=4 SEEDS="0" bash submit_concrete.sh
+EMAIL=tgardos@bu.edu NGPUS=4 RUN_PREFIX=SWIN_L_384_CONCRETE_4GPU \
+  CONFIG=configs_advanced/swin_large_384_concrete_4gpu.yml SEEDS="0" \
+  bash submit_concrete.sh
 ```
-`NGPUS=4` requests `gpus=4`, `omp 32`, and triggers torchrun (4 processes, 1 per GPU).
+`NGPUS=4` requests `gpus=4`, `omp 32`, and triggers torchrun (4 processes, 1 per GPU). For
+**2 GPUs**, use `grad_accum: 4` instead (edit the config or pass it inline as below).
 
 **4-GPU run via direct qsub** (grad-accum passed inline, no config edit):
 ```bash

--- a/finetuning/SWIN/CONCRETE_RUN_README.md
+++ b/finetuning/SWIN/CONCRETE_RUN_README.md
@@ -139,8 +139,10 @@ SEEDS="0 1 2 3 4" bash submit_concrete.sh
 ```
 
 Each job requests 1 A100-80G GPU on `herbdl` for 48h and writes to
-`finetuning/output/SWIN/SWIN_L_384_CONCRETE_SEED<seed>/`. Adjust the `-M` email in
-`submit_concrete.sh` if needed.
+`finetuning/output/SWIN/SWIN_L_384_CONCRETE_SEED<seed>/` (in your own workspace). Set
+`EMAIL=you@bu.edu` for job notifications (it otherwise defaults to the script author).
+**A single 1-GPU job will not finish 100 epochs in 48h — see "Runtime" below for the
+multi-GPU and resume options.**
 
 ### Smoke test first (recommended)
 Verify the pipeline end-to-end cheaply before committing 48h jobs:
@@ -151,6 +153,60 @@ qsub -l h_rt=2:00:00 -pe omp 8 -P herbdl -l gpus=1 -l gpu_c=8.0 -l gpu_memory=80
 -v SET_ARGS="--set data.max_train_samples=2000 --set data.max_eval_samples=2000 --set training.num_train_epochs=1 --set training.output_dir=/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SMOKE --set training.overwrite_output_dir=true --set wandb.enabled=false" \
      train_advanced.sh
 ```
+
+## Runtime: 48h wall limit, multi-GPU (DDP), and resuming
+
+The full run is **100 epochs × ~671,817 images** at effective batch 128 = **524,900
+optimization steps**. On **1 A100-80G** it settles at ~1.2 s/step ≈ **~175h (~7 days)** — far
+past the **48h** job wall limit (`-l h_rt=48:00:00`), so a single 1-GPU job only reaches
+~epoch 27 before SGE kills it. Three options, combinable:
+
+**1. Resume across jobs (no changes).** A checkpoint is saved every epoch
+(`save_strategy: epoch`, ~1.8h on 1 GPU) and the trainer auto-resumes from the latest one when
+you resubmit to the same `output_dir` (`overwrite_output_dir: false`). Just rerun the same
+command after each 48h job ends — ~4 sequential jobs reach 100 epochs.
+
+**2. Multi-GPU / DDP — recommended.** `submit_concrete.sh` honors `NGPUS`, which sets
+`NPROC_PER_NODE` so `train_advanced.sh` launches via `torchrun`. Wall-time scales ~linearly:
+
+| GPUs | grad_accum for eff. batch 128 | ~wall time (100 ep) |
+|------|-------------------------------|---------------------|
+| 1    | 8 (default)                   | ~175h → needs resume |
+| 2    | 4                             | ~88h → needs resume  |
+| 4    | 2                             | ~44h → ≈ one 48h job |
+
+⚠️ **DDP multiplies the effective batch by `NGPUS`** (each GPU runs its own
+`per_device_batch × grad_accum`). The config targets effective batch **128**, so **reduce
+`gradient_accumulation_steps`** to keep it there (and keep the LR valid). `submit_concrete.sh`
+doesn't forward extra `--set` args, so either set `gradient_accumulation_steps: 2` in
+`configs_advanced/swin_large_384_concrete.yml` for the multi-GPU run, or submit directly
+(below) for full control.
+
+**4-GPU run via the launcher** (set `gradient_accumulation_steps: 2` in the config first):
+```bash
+cd finetuning/SWIN
+EMAIL=tgardos@bu.edu NGPUS=4 SEEDS="0" bash submit_concrete.sh
+```
+`NGPUS=4` requests `gpus=4`, `omp 32`, and triggers torchrun (4 processes, 1 per GPU).
+
+**4-GPU run via direct qsub** (grad-accum passed inline, no config edit):
+```bash
+cd finetuning/SWIN
+OUT=/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SWIN_L_384_CONCRETE_SEED0
+qsub -l h_rt=48:00:00 -pe omp 32 -P herbdl -l gpus=4 -l gpu_c=8.0 -l gpu_memory=80G \
+     -m beas -M tgardos@bu.edu -N SWINL384_S0 \
+     -v CONFIG_FILE=configs_advanced/swin_large_384_concrete.yml,NPROC_PER_NODE=4,\
+SET_ARGS="--set training.gradient_accumulation_steps=2 --set training.seed=0 --set training.output_dir=$OUT --set training.logging_dir=$OUT" \
+     train_advanced.sh
+```
+
+**3. Fewer epochs.** 100 is generous — the 224-px curriculum plateaued by ~50 epochs. Trim with
+`--set training.num_train_epochs=50` for a faster first result; resume-extend later.
+
+> Effective-batch note: DDP at 4 GPUs with `grad_accum=2` keeps the global batch at
+> `16 × 2 × 4 = 128`, matching the 1-GPU recipe. If you intentionally let it grow (e.g.
+> `grad_accum=8` on 4 GPUs → batch 512), scale the LR up accordingly and expect different
+> convergence.
 
 ## Output paths auto-relocate to your workspace
 

--- a/finetuning/SWIN/configs_advanced/swin_large_384_concrete_4gpu.yml
+++ b/finetuning/SWIN/configs_advanced/swin_large_384_concrete_4gpu.yml
@@ -1,0 +1,147 @@
+# =============================================================================
+# Concrete next run — 4-GPU (DDP) variant
+# =============================================================================
+# Identical to swin_large_384_concrete.yml EXCEPT gradient_accumulation_steps is 2
+# (not 8), so under DDP across 4 GPUs the effective batch stays 128
+# (16 per-device x 2 accum x 4 GPUs = 128), matching the 1-GPU recipe.
+# Same levers: SWIN-L @384 in22k, balanced-softmax + multi-task, medium aug, EMA,
+# 100 epochs, TTA wired for inference.
+#
+# Launch (NGPUS triggers torchrun via train_advanced.sh's NPROC_PER_NODE):
+#   EMAIL=you@bu.edu NGPUS=4 RUN_PREFIX=SWIN_L_384_CONCRETE_4GPU \
+#     CONFIG=configs_advanced/swin_large_384_concrete_4gpu.yml SEEDS="0" \
+#     bash submit_concrete.sh
+# ~44h for 100 epochs (≈ one 48h wall-time window). For 2 GPUs use grad_accum 4.
+# (submit_concrete.sh overrides training.seed / output_dir / run_id per seed.)
+# =============================================================================
+
+model:
+  model_name_or_path: "microsoft/swin-large-patch4-window12-384-in22k"
+  config_name: "microsoft/swin-large-patch4-window12-384-in22k"
+  cache_dir: null
+  model_revision: "main"
+  image_processor_name: "microsoft/swin-large-patch4-window12-384-in22k"
+  token: null
+  trust_remote_code: false
+  ignore_mismatched_sizes: true
+
+data:
+  dataset_name: null
+  dataset_config_name: null
+  data_file: null
+  data_dir: null
+  train_file: "/projectnb/herbdl/data/kaggle-herbaria/train_2022.json"
+  validation_file: "/projectnb/herbdl/data/kaggle-herbaria/val_2022.json"
+  image_column_name: "filename"
+  label_column_name: "scientificNameEncoded"
+  max_seq_length: 15
+  max_train_samples: null
+  max_eval_samples: 50000
+  overwrite_cache: false
+  preprocessing_num_workers: null
+  train_val_split: 0.2
+
+training:
+  output_dir: "/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SWIN_L_384_CONCRETE_4GPU_SEED0"
+  logging_dir: "/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SWIN_L_384_CONCRETE_4GPU_SEED0"
+  do_train: true
+  do_eval: true
+  per_device_train_batch_size: 16
+  per_device_eval_batch_size: 8
+  learning_rate: 0.0001
+  num_train_epochs: 100
+  warmup_steps: 0.05
+  weight_decay: 0.05
+  gradient_accumulation_steps: 2          # 4-GPU DDP: 16 * 2 * 4 GPUs = effective batch 128
+  gradient_checkpointing: true            # needed to fit SWIN-L @384 (wrappers pass it through)
+  lr_scheduler_type: "cosine"
+  lr_scheduler_kwargs:
+    eta_min: 0.000001
+  logging_strategy: "epoch"
+  save_strategy: "epoch"
+  save_total_limit: 3
+  eval_strategy: "epoch"
+  eval_on_start: true
+  load_best_model_at_end: false           # EMA copies averaged weights in at train end; do not reload "best"
+  report_to: "wandb"
+  bf16: true
+  dataloader_num_workers: 8
+  remove_unused_columns: false
+  overwrite_output_dir: false
+  seed: 0
+
+custom:
+  lr_type: "cosine"
+  frozen: false
+  frozen_type: "none"
+  run_group: "SWIN_L_384_Concrete_4GPU"
+  run_name: "SWIN_L_384_Concrete_4GPU_Seed0"
+  run_id: "swin_l_384_concrete_4gpu_seed0"
+  run_notes: "Concrete run, 4-GPU DDP (grad_accum 2 -> eff batch 128): SWIN-L 384 in22k, balanced-softmax + multi-task CE, medium aug, EMA, 100ep. Seed 0."
+
+augmentation:
+  use_advanced: true
+  randaugment:
+    num_ops: 2
+    magnitude: 7                          # MEDIUM (not 9) — cold start, see curriculum finding
+  mixup:
+    enabled: true
+    alpha: 0.8
+  cutmix:
+    enabled: true
+    alpha: 1.0
+  mixup_cutmix_prob: 0.3                   # mild mixing for a cold backbone
+  label_smoothing: 0.1
+  random_erasing:
+    enabled: true
+    probability: 0.15
+    min_area: 0.02
+    max_area: 0.33
+  color_jitter:
+    enabled: true
+    brightness: 0.4
+    contrast: 0.4
+    saturation: 0.4
+    hue: 0.1
+
+multi_task:
+  enabled: true
+  min_species_samples: 2
+  family_weight: 0.2
+  genus_weight: 0.3
+  species_weight: 1.0
+
+# Balanced softmax / logit adjustment (Tier 1.3-A). Adds tau * log(class_prior) to the
+# species logits during TRAINING only (off at inference) to lift macro-F1 on the long tail.
+long_tail:
+  logit_adjustment: true
+  tau: 1.0
+
+# Weight EMA (Tier 2.6). EMA weights are copied into the model at train end, so the
+# final eval/save reflect them. Keep load_best_model_at_end false (see above).
+ema:
+  enabled: true
+  decay: 0.9998
+
+# Multi-crop + horizontal-flip TTA (Tier 2.7). Leave disabled during training; enable
+# for the final/leaderboard prediction (crops are sized around the 384 target).
+multi_crop:
+  enabled: false
+  crop_sizes: [400, 416, 448, 480, 512]
+  target_size: 384
+  flip: true
+
+# ArcFace deferred (Tier 2.4) — kept off for this run.
+arcface:
+  enabled: false
+  embedding_size: 512
+  scale: 30.0
+  margin: 0.50
+  num_subcenters: 3
+  hybrid_ce_weight: 0.0
+
+wandb:
+  enabled: true
+  entity: "gardoslab"
+  project: "herbdl"
+  resume: "allow"


### PR DESCRIPTION
## What

Adds a **Runtime** section to `CONCRETE_RUN_README.md` documenting that the full SWIN-L 384
concrete run (100 epochs × 671,817 images, effective batch 128 = **524,900 steps**) takes
**~175h on one A100** and so **won't complete in the 48h job wall limit** (a 1-GPU job stops
around epoch 27).

## Options documented

1. **Resume across jobs** — per-epoch checkpoints + auto-resume to the same `output_dir`; just
   resubmit (~4 jobs for 100 epochs).
2. **Multi-GPU / DDP (recommended)** via `submit_concrete.sh`'s `NGPUS` (sets `NPROC_PER_NODE`
   → `torchrun`). Includes a table mapping GPUs → `gradient_accumulation_steps` to **keep the
   effective batch at 128** (DDP multiplies batch by `NGPUS`): 4 GPUs → `grad_accum=2` → ~44h
   ≈ one wall-time window. Both launcher and direct-`qsub` 4-GPU recipes are given.
3. **Fewer epochs** (e.g. 50) for a faster first result.

Also notes `EMAIL=you@bu.edu` for job notifications and cross-links from the launch section.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)