### PR TITLE
Add 2-GPU (DDP) concrete config + README recipe

### DIFF
--- a/finetuning/SWIN/CONCRETE_RUN_README.md
+++ b/finetuning/SWIN/CONCRETE_RUN_README.md
@@ -188,8 +188,17 @@ EMAIL=tgardos@bu.edu NGPUS=4 RUN_PREFIX=SWIN_L_384_CONCRETE_4GPU \
   CONFIG=configs_advanced/swin_large_384_concrete_4gpu.yml SEEDS="0" \
   bash submit_concrete.sh
 ```
-`NGPUS=4` requests `gpus=4`, `omp 32`, and triggers torchrun (4 processes, 1 per GPU). For
-**2 GPUs**, use `grad_accum: 4` instead (edit the config or pass it inline as below).
+`NGPUS=4` requests `gpus=4`, `omp 32`, and triggers torchrun (4 processes, 1 per GPU).
+
+**2-GPU run** (often schedules faster — more nodes have 2 free GPUs than 4; ~88h, one resume).
+Uses [`configs_advanced/swin_large_384_concrete_2gpu.yml`](configs_advanced/swin_large_384_concrete_2gpu.yml)
+(`grad_accum: 4` → `16 × 4 × 2 = 128`):
+```bash
+cd finetuning/SWIN
+EMAIL=tgardos@bu.edu NGPUS=2 RUN_PREFIX=SWIN_L_384_CONCRETE_2GPU \
+  CONFIG=configs_advanced/swin_large_384_concrete_2gpu.yml SEEDS="0" \
+  bash submit_concrete.sh
+```
 
 **4-GPU run via direct qsub** (grad-accum passed inline, no config edit):
 ```bash

--- a/finetuning/SWIN/configs_advanced/swin_large_384_concrete_2gpu.yml
+++ b/finetuning/SWIN/configs_advanced/swin_large_384_concrete_2gpu.yml
@@ -1,0 +1,150 @@
+# =============================================================================
+# Concrete next run — 2-GPU (DDP) variant
+# =============================================================================
+# Identical to swin_large_384_concrete.yml EXCEPT gradient_accumulation_steps is 4
+# (not 8), so under DDP across 2 GPUs the effective batch stays 128
+# (16 per-device x 4 accum x 2 GPUs = 128), matching the 1-GPU recipe.
+# Same levers: SWIN-L @384 in22k, balanced-softmax + multi-task, medium aug, EMA,
+# 100 epochs, TTA wired for inference.
+#
+# Why 2 GPUs: easier to schedule than 4-on-one-node (more nodes have 2 free).
+# ~88h for 100 epochs, so plan on one resume across 48h jobs (auto-resumes from
+# the per-epoch checkpoint in output_dir).
+#
+# Launch (NGPUS triggers torchrun via train_advanced.sh's NPROC_PER_NODE):
+#   EMAIL=you@bu.edu NGPUS=2 RUN_PREFIX=SWIN_L_384_CONCRETE_2GPU \
+#     CONFIG=configs_advanced/swin_large_384_concrete_2gpu.yml SEEDS="0" \
+#     bash submit_concrete.sh
+# (submit_concrete.sh overrides training.seed / output_dir / run_id per seed.)
+# =============================================================================
+
+model:
+  model_name_or_path: "microsoft/swin-large-patch4-window12-384-in22k"
+  config_name: "microsoft/swin-large-patch4-window12-384-in22k"
+  cache_dir: null
+  model_revision: "main"
+  image_processor_name: "microsoft/swin-large-patch4-window12-384-in22k"
+  token: null
+  trust_remote_code: false
+  ignore_mismatched_sizes: true
+
+data:
+  dataset_name: null
+  dataset_config_name: null
+  data_file: null
+  data_dir: null
+  train_file: "/projectnb/herbdl/data/kaggle-herbaria/train_2022.json"
+  validation_file: "/projectnb/herbdl/data/kaggle-herbaria/val_2022.json"
+  image_column_name: "filename"
+  label_column_name: "scientificNameEncoded"
+  max_seq_length: 15
+  max_train_samples: null
+  max_eval_samples: 50000
+  overwrite_cache: false
+  preprocessing_num_workers: null
+  train_val_split: 0.2
+
+training:
+  output_dir: "/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SWIN_L_384_CONCRETE_2GPU_SEED0"
+  logging_dir: "/projectnb/herbdl/workspaces/tgardos/herbdl/finetuning/output/SWIN/SWIN_L_384_CONCRETE_2GPU_SEED0"
+  do_train: true
+  do_eval: true
+  per_device_train_batch_size: 16
+  per_device_eval_batch_size: 8
+  learning_rate: 0.0001
+  num_train_epochs: 100
+  warmup_steps: 0.05
+  weight_decay: 0.05
+  gradient_accumulation_steps: 4          # 2-GPU DDP: 16 * 4 * 2 GPUs = effective batch 128
+  gradient_checkpointing: true            # needed to fit SWIN-L @384 (wrappers pass it through)
+  lr_scheduler_type: "cosine"
+  lr_scheduler_kwargs:
+    eta_min: 0.000001
+  logging_strategy: "epoch"
+  save_strategy: "epoch"
+  save_total_limit: 3
+  eval_strategy: "epoch"
+  eval_on_start: true
+  load_best_model_at_end: false           # EMA copies averaged weights in at train end; do not reload "best"
+  report_to: "wandb"
+  bf16: true
+  dataloader_num_workers: 8
+  remove_unused_columns: false
+  overwrite_output_dir: false
+  seed: 0
+
+custom:
+  lr_type: "cosine"
+  frozen: false
+  frozen_type: "none"
+  run_group: "SWIN_L_384_Concrete_2GPU"
+  run_name: "SWIN_L_384_Concrete_2GPU_Seed0"
+  run_id: "swin_l_384_concrete_2gpu_seed0"
+  run_notes: "Concrete run, 2-GPU DDP (grad_accum 4 -> eff batch 128): SWIN-L 384 in22k, balanced-softmax + multi-task CE, medium aug, EMA, 100ep. Seed 0."
+
+augmentation:
+  use_advanced: true
+  randaugment:
+    num_ops: 2
+    magnitude: 7                          # MEDIUM (not 9) — cold start, see curriculum finding
+  mixup:
+    enabled: true
+    alpha: 0.8
+  cutmix:
+    enabled: true
+    alpha: 1.0
+  mixup_cutmix_prob: 0.3                   # mild mixing for a cold backbone
+  label_smoothing: 0.1
+  random_erasing:
+    enabled: true
+    probability: 0.15
+    min_area: 0.02
+    max_area: 0.33
+  color_jitter:
+    enabled: true
+    brightness: 0.4
+    contrast: 0.4
+    saturation: 0.4
+    hue: 0.1
+
+multi_task:
+  enabled: true
+  min_species_samples: 2
+  family_weight: 0.2
+  genus_weight: 0.3
+  species_weight: 1.0
+
+# Balanced softmax / logit adjustment (Tier 1.3-A). Adds tau * log(class_prior) to the
+# species logits during TRAINING only (off at inference) to lift macro-F1 on the long tail.
+long_tail:
+  logit_adjustment: true
+  tau: 1.0
+
+# Weight EMA (Tier 2.6). EMA weights are copied into the model at train end, so the
+# final eval/save reflect them. Keep load_best_model_at_end false (see above).
+ema:
+  enabled: true
+  decay: 0.9998
+
+# Multi-crop + horizontal-flip TTA (Tier 2.7). Leave disabled during training; enable
+# for the final/leaderboard prediction (crops are sized around the 384 target).
+multi_crop:
+  enabled: false
+  crop_sizes: [400, 416, 448, 480, 512]
+  target_size: 384
+  flip: true
+
+# ArcFace deferred (Tier 2.4) — kept off for this run.
+arcface:
+  enabled: false
+  embedding_size: 512
+  scale: 30.0
+  margin: 0.50
+  num_subcenters: 3
+  hybrid_ce_weight: 0.0
+
+wandb:
+  enabled: true
+  entity: "gardoslab"
+  project: "herbdl"
+  resume: "allow"


### PR DESCRIPTION
## What

Adds `configs_advanced/swin_large_384_concrete_2gpu.yml` — a 2-GPU DDP variant of the concrete
SWIN-L 384 run, mirroring the existing 4-GPU config. Only `gradient_accumulation_steps` differs
from the base (4 instead of 8), keeping the effective batch at **128** under 2-GPU DDP
(`16 × 4 × 2`). Distinct `output_dir`/run names so it won't collide with the 1- or 4-GPU runs.

## Why

On a live check, **0 of the 22 cc≥8.0/80G nodes currently had 4 GPUs free on a single node**
(most had 0–2), which is why a 4-GPU single-node job queues. A **2-GPU** job schedules more
easily (several nodes have 2 free) at ~88h / one resume — a good fallback or middle ground
between the 1-GPU (~175h) and 4-GPU (~44h) runs.

## Launch

```bash
EMAIL=tgardos@bu.edu NGPUS=2 RUN_PREFIX=SWIN_L_384_CONCRETE_2GPU   CONFIG=configs_advanced/swin_large_384_concrete_2gpu.yml SEEDS="0"   bash submit_concrete.sh
```

README's multi-GPU section documents it alongside the 4-GPU recipe. Config-only; verified it
parses and that the effective batch is 128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)