### PR TITLE
submit_concrete.sh: default wall time to 24h (H_RT) to match herbdl GPU access

### DIFF
--- a/finetuning/SWIN/CONCRETE_RUN_README.md
+++ b/finetuning/SWIN/CONCRETE_RUN_README.md
@@ -242,6 +242,25 @@ single-node request right now. No rows for `f>=4` but several for `f>=2` is exac
 4-GPU run queues longer than the 2-GPU run. Knobs: `cc>=8` (8.0 = A100, 9.0 = H200), `m>=80`
 (min GB), `f>=N` (free GPUs on one node).
 
+#### Wall time matters more than you'd expect — keep it ≤ 24h
+
+Seeing idle GPUs but still stuck in `qw`? Most free GPU nodes are **buy-in** queues, and
+project `herbdl`'s access to them is **time-capped**:
+
+| Queue type | herbdl access | max `h_rt` |
+|------------|---------------|-----------|
+| `cds-gpu-long` (CDS buy-in) | yes | **24h** |
+| `cds-gpu`, public `*-pub` queues | yes | **12h** |
+| other groups' queues (`ece*`, `chapmangroup*`) | no | — |
+| shared long-GPU pool | yes | 48h, but scarce |
+
+A job requesting **`h_rt=48h` is locked out of every queue herbdl can borrow** (they cap at
+24h/12h) and waits behind the limited shared long-GPU pool — even while CDS/public GPUs sit
+idle. So **request ≤24h** and let per-epoch checkpoint + auto-resume carry the run across
+jobs. `submit_concrete.sh` now defaults `H_RT=24:00:00`; override with `H_RT=12:00:00` for the
+widest (public) queue access, or check eligibility/caps with
+`qconf -sq <queue>` (look at `projects` and `h_rt`).
+
 ## Output paths auto-relocate to your workspace
 
 Most configs in this repo (inherited from faridkar's) hardcode `output_dir`/`logging_dir`

--- a/finetuning/SWIN/submit_concrete.sh
+++ b/finetuning/SWIN/submit_concrete.sh
@@ -10,6 +10,11 @@
 #   SEEDS       — space-separated    (default: "0 1 2")
 #   NGPUS       — GPUs per job       (default: 1; set to 2 for multi-GPU / DDP)
 #   GPU_MEM     — GPU memory request (default: 80G)
+#   H_RT        — wall-time limit     (default: 24:00:00)
+#                 NOTE: project herbdl's GPU access caps at 24h (cds-gpu-long) / 12h
+#                 (public buy-in queues). Requesting >24h locks the job out of those
+#                 queues, so it waits behind the scarce shared long-GPU pool. Keep <=24h
+#                 and rely on per-epoch checkpoint + auto-resume across jobs.
 #   CKPT        — warm-start checkpoint dir (overrides model.model_name_or_path)
 #   EMAIL       — notification email (default: faridkar@bu.edu)
 #
@@ -38,9 +43,13 @@ OUT_BASE=${OUT_BASE:-"${REPO_ROOT}/finetuning/output/SWIN"}
 NGPUS=${NGPUS:-1}
 GPU_MEM=${GPU_MEM:-"80G"}
 EMAIL=${EMAIL:-"faridkar@bu.edu"}
+# 24h (not 48h): herbdl's GPU queues cap at 24h (cds-gpu-long) / 12h (public); a >24h
+# request can't use them and queues behind the scarce shared long-GPU pool. Checkpoints
+# are saved per epoch and the trainer auto-resumes, so multi-job runs are seamless.
+H_RT=${H_RT:-"24:00:00"}
 
 OMP_THREADS=$(( NGPUS * 8 ))
-QSUB_ARGS="-l h_rt=48:00:00 -pe omp ${OMP_THREADS} -P herbdl -l gpus=${NGPUS} -l gpu_c=8.0 -l gpu_memory=${GPU_MEM} -m beas -M ${EMAIL}"
+QSUB_ARGS="-l h_rt=${H_RT} -pe omp ${OMP_THREADS} -P herbdl -l gpus=${NGPUS} -l gpu_c=8.0 -l gpu_memory=${GPU_MEM} -m beas -M ${EMAIL}"
 
 # Pass NPROC_PER_NODE only when using multiple GPUs (triggers torchrun in train_advanced.sh)
 NPROC_VAR=""


### PR DESCRIPTION
## Problem

`submit_concrete.sh` hardcoded `h_rt=48:00:00`. But project `herbdl`'s GPU-queue access caps
at **24h** (`cds-gpu-long`) and **12h** (`cds-gpu` + public buy-in queues); the other free
nodes belong to groups herbdl can't use (`ece*`, `chapmangroup*`). A 48h request is therefore
**ineligible for every queue herbdl can borrow**, so the job sits in `qw` behind the scarce
shared long-GPU pool — even while CDS/public 80G GPUs sit idle (observed live: `scc-a16` idle
with 2 free GPUs, but unreachable by a 48h job).

## Change

- Add an **`H_RT` env var** to `submit_concrete.sh`, default **`24:00:00`** (was hardcoded 48h),
  used in `QSUB_ARGS`. Override e.g. `H_RT=12:00:00` for widest (public) queue access.
- README: a "Wall time matters" table + note explaining the per-queue caps and why ≤24h
  schedules far faster, leaning on per-epoch checkpoint + auto-resume across jobs.

Verified `bash -n` and that `H_RT` resolves (default 24h, override honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)