### PR TITLE
Fix DDP crash: non-reentrant gradient checkpointing for multi-GPU runs

### DIFF
--- a/finetuning/SWIN/configs_advanced/swin_large_384_concrete_2gpu.yml
+++ b/finetuning/SWIN/configs_advanced/swin_large_384_concrete_2gpu.yml
@@ -57,6 +57,9 @@ training:
   weight_decay: 0.05
   gradient_accumulation_steps: 4          # 2-GPU DDP: 16 * 4 * 2 GPUs = effective batch 128
   gradient_checkpointing: true            # needed to fit SWIN-L @384 (wrappers pass it through)
+  gradient_checkpointing_kwargs:
+    use_reentrant: false                  # REQUIRED under DDP: reentrant checkpointing fires
+                                          # autograd hooks twice -> "marked as ready twice" crash
   lr_scheduler_type: "cosine"
   lr_scheduler_kwargs:
     eta_min: 0.000001

--- a/finetuning/SWIN/configs_advanced/swin_large_384_concrete_4gpu.yml
+++ b/finetuning/SWIN/configs_advanced/swin_large_384_concrete_4gpu.yml
@@ -54,6 +54,9 @@ training:
   weight_decay: 0.05
   gradient_accumulation_steps: 2          # 4-GPU DDP: 16 * 2 * 4 GPUs = effective batch 128
   gradient_checkpointing: true            # needed to fit SWIN-L @384 (wrappers pass it through)
+  gradient_checkpointing_kwargs:
+    use_reentrant: false                  # REQUIRED under DDP: reentrant checkpointing fires
+                                          # autograd hooks twice -> "marked as ready twice" crash
   lr_scheduler_type: "cosine"
   lr_scheduler_kwargs:
     eta_min: 0.000001


### PR DESCRIPTION
## Problem

The 2-GPU / 4-GPU concrete runs crash shortly after starting (under DDP) with:

```
[rank1]: Parameter at index 419 with name swin.encoder.layers.3.blocks.1.output.dense.weight
has been marked as ready twice. This means that multiple autograd engine hooks have fired for
this particular parameter during this iteration.
```

HuggingFace gradient checkpointing defaults to **reentrant** mode (`use_reentrant=True`), which
re-runs the forward pass during backward and fires DistributedDataParallel's gradient-ready
hooks twice per parameter → DDP aborts. This only manifests under DDP, so the single-GPU run
was fine while the multi-GPU runs died.

(The run was otherwise healthy: it scheduled at 48G on a CDS node, resumed from the epoch-7
checkpoint, and evaluated at `accuracy 0.590 / species_f1 0.531` before the crash.)

## Fix

Set non-reentrant checkpointing in both multi-GPU configs:

```yaml
training:
  gradient_checkpointing: true
  gradient_checkpointing_kwargs:
    use_reentrant: false
```

The trainer already forwards `gradient_checkpointing_kwargs` to `TrainingArguments`, and the
`MultiTaskSwinModel`/`SwinWithArcFace` `gradient_checkpointing_enable(**kwargs)` passthrough
relays it to the backbone. Verified the configs parse and `TrainingArguments` accepts the
kwarg. Single-GPU base config left unchanged (reentrant is fine without DDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)